### PR TITLE
add welcome redirect

### DIFF
--- a/src/main/resources/META-INF/keycloak-themes.json
+++ b/src/main/resources/META-INF/keycloak-themes.json
@@ -1,6 +1,6 @@
 {
     "themes": [{
         "name" : "fedRAMP",
-        "types": [ "login", "account" ]
+        "types": [ "login", "account", "welcome" ]
     }]
 }

--- a/src/main/resources/theme/fedRAMP/welcome/index.ftl
+++ b/src/main/resources/theme/fedRAMP/welcome/index.ftl
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="refresh" content="0; url=/realms/redhat-external/account/#/security/signingin" />
+    <meta name="robots" content="noindex, nofollow" />
+    <script type="text/javascript">
+        window.location.href = '/realms/redhat-external/account/#/security/signingin'
+    </script>
+</head>
+<body>
+If you are not redirected automatically, follow this <a href="/realms/redhat-external/account/#/security/signingin">link</a>.
+</body>
+</html>

--- a/src/main/resources/theme/fedRAMP/welcome/theme.properties
+++ b/src/main/resources/theme/fedRAMP/welcome/theme.properties
@@ -1,0 +1,2 @@
+parent=keycloak
+locales=en


### PR DESCRIPTION
Keycloak root URI landing page should redirect to user's most accessed page, redhat-external sign-in